### PR TITLE
Fix tiny typo in Net::HTTP write_timeout title

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -617,7 +617,7 @@ Ruby <a class="ruby-doc" href="https://ruby-doc.org/core-2.6/TracePoint.html"><c
 * `URI` now can open `file://` URIs, `URI::File` class added.
   * **Documentation:** <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.6/libdoc/uri/rdoc/URI/File.html"><code>URI::File</code></a>
   * **Discussion:** <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/14035">Feature #14035</a>
-* `Net::HTTP`: `write_timout` added
+* `Net::HTTP`: `write_timeout` added
   * **Documentation:** <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.6/libdoc/net/http/rdoc/Net/HTTP.html#method-i-write_timeout-3D"><code>Net::HTTP#write_timeout=</code></a>
   * **Discussion:** <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/13396">Feature #13396</a>
 * `Net::HTTPServerError` renamed to `Net::HTTPClientException`

--- a/_src/2.6.md
+++ b/_src/2.6.md
@@ -617,7 +617,7 @@ Ruby [TracePoint](https://ruby-doc.org/core-2.6/TracePoint.html) API allows to o
 * `URI` now can open `file://` URIs, `URI::File` class added.
   * **Documentation:** [URI::File](https://ruby-doc.org/stdlib-2.6/libdoc/uri/rdoc/URI/File.html)
   * **Discussion:** [Feature #14035](https://bugs.ruby-lang.org/issues/14035)
-* `Net::HTTP`: `write_timout` added
+* `Net::HTTP`: `write_timeout` added
   * **Documentation:** [Net::HTTP#write_timeout=](https://ruby-doc.org/stdlib-2.6/libdoc/net/http/rdoc/Net/HTTP.html#method-i-write_timeout-3D)
   * **Discussion:** [Feature #13396](https://bugs.ruby-lang.org/issues/13396)
 * `Net::HTTPServerError` renamed to `Net::HTTPClientException`


### PR DESCRIPTION
just fixed a simple typo that I noticed.

P.S. very cool and informative resource, thank you! 👍 