### PR TITLE
[2.7] update pattern maching rdoc link

### DIFF
--- a/2.4.md
+++ b/2.4.md
@@ -15,9 +15,9 @@ prev: 2.5
  -->
 
 * **Released at:** Dec 25, 2016 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.4.0) file)
-* **Status (as of Dec 28, 2019):** EOL soon, latest is 2.4.9
+* **Status (as of Feb 28, 2020):** EOL soon, latest is 2.4.9
 * **This document first published:** Oct 14, 2019
-* **Last change to this document:** Dec 28, 2019
+* **Last change to this document:** Feb 28, 2020
 
 ## Highlights[](#highlights)
 

--- a/2.5.md
+++ b/2.5.md
@@ -15,9 +15,9 @@ prev: 2.6
  -->
 
 * **Released at:** Dec 25, 2017 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.5.0) file)
-* **Status (as of Dec 27, 2019):** active, latest is 2.5.7
+* **Status (as of Feb 28, 2020):** active, latest is 2.5.7
 * **This document first published:** Jun 6, 2019
-* **Last change to this document:** Dec 27, 2019
+* **Last change to this document:** Feb 28, 2020
 
 ## Highlights[](#highlights)
 

--- a/2.6.md
+++ b/2.6.md
@@ -7,9 +7,9 @@ next: 2.5
 # Ruby 2.6
 
 * **Released at:** Dec 25, 2018 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_6/NEWS) file)
-* **Status (as of Dec 27, 2019):** 2.6.5 is current _stable_
+* **Status (as of Feb 28, 2020):** 2.6.5 is current _stable_
 * **This document first published:** Dec 29, 2018
-* **Last change to this document:** Dec 27, 2019
+* **Last change to this document:** Feb 28, 2020
 
 > **Note:** As already explained in [Introduction](README.md), this site is dedicated to changes in the **language**, not the **implementation**, therefore the list below lacks mentions of lots of important optimization introduced in 2.6, including the whole JIT big thing. That's not because they are not important, just because this site's goals are different.
 

--- a/2.7.md
+++ b/2.7.md
@@ -32,7 +32,7 @@ Ruby 2.7 is a last major release before 3.0¹, so it introduces several importan
 
 ### Pattern matching[](#pattern-matching)
 
-Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
+Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. **[documentation](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
 
 ```ruby
 require 'open-uri'

--- a/2.7.md
+++ b/2.7.md
@@ -7,9 +7,9 @@ next: 2.6
 # Ruby 2.7
 
 * **Released at:** Dec 25, 2019 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_7/NEWS) file)
-* **Status (as of Dec 28, 2019):** 2.7.0 is current _stable_
+* **Status (as of Feb 28, 2020):** 2.7.0 is current _stable_
 * **This document first published:** Dec 27, 2019
-* **Last change to this document:** Dec 28, 2019
+* **Last change to this document:** Feb 28, 2020
 
 <!-- TODO: all links to docs should be replaced with /2.7.0/ suffix instead of /master/ when 2.7.0 would be published -->
 
@@ -32,7 +32,7 @@ Ruby 2.7 is a last major release before 3.0¹, so it introduces several importan
 
 ### Pattern matching[](#pattern-matching)
 
-Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/zverok/ruby/blob/pattern-matching-docs/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
+Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
 
 ```ruby
 require 'open-uri'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'memoist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    memoist (0.16.2)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
     minima (2.5.0)
@@ -243,6 +244,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  memoist
 
 BUNDLED WITH
    1.17.2

--- a/_src/2.7.md
+++ b/_src/2.7.md
@@ -32,7 +32,7 @@ Ruby 2.7 is a last major release before 3.0¹, so it introduces several importan
 
 ### Pattern matching
 
-Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
+Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. **[documentation](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
 
 ```ruby
 require 'open-uri'

--- a/_src/2.7.md
+++ b/_src/2.7.md
@@ -32,7 +32,7 @@ Ruby 2.7 is a last major release before 3.0¹, so it introduces several importan
 
 ### Pattern matching
 
-Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/zverok/ruby/blob/pattern-matching-docs/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
+Pattern matching is a completely new and experimental feature for structural value checking against patterns, and local variable binding. As it is new and huge, we'll not try to cover the feature here and just send the reader to the official documentation. Unfortunately, the one was not merged before the 2.7 release, so the best we can do currently is to link to **[documentation candidate](https://github.com/ruby/ruby/blob/master/doc/syntax/pattern_matching.rdoc)** _(disclaimer: it is written by author of the current changelog)_. Just a small example:
 
 ```ruby
 require 'open-uri'


### PR DESCRIPTION
zverok has moved this rdoc to ruby master branch.
the origin one links to a 404 page now.
we should update the link.
checkout the commit from the link below. 
https://github.com/ruby/ruby/commit/281b3500580f9ec93ee17679c648eaeb4a47f8b6