### PR TITLE
Fix various typos, etc.

### DIFF
--- a/2.4.md
+++ b/2.4.md
@@ -15,9 +15,9 @@ prev: 2.5
  -->
 
 * **Released at:** Dec 25, 2016 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.4.0) file)
-* **Status (as of Dec 28, 2019):** EOL soon, latest is 2.4.9
+* **Status (as of Aug 23, 2020):** EOL, latest is 2.4.10
 * **This document first published:** Oct 14, 2019
-* **Last change to this document:** Dec 28, 2019
+* **Last change to this document:** Aug 23, 2020
 
 ## Highlights[](#highlights)
 
@@ -155,7 +155,7 @@ Returns an array of all modules used in the current scope.
 
 ### `Warning` module[](#warning-module)
 
-New single-method module was introduced, meant to be overriden in order to control warnings issued by Ruby.
+New single-method module was introduced, meant to be overridden in order to control warnings issued by Ruby.
 
 * **Reason:**
 * **Discussion:** <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/12299">Feature #12299</a>

--- a/2.5.md
+++ b/2.5.md
@@ -15,9 +15,9 @@ prev: 2.6
  -->
 
 * **Released at:** Dec 25, 2017 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.5.0) file)
-* **Status (as of Dec 27, 2019):** active, latest is 2.5.7
+* **Status (as of Aug 23, 2020):** Security maintenance, latest is 2.5.8
 * **This document first published:** Jun 6, 2019
-* **Last change to this document:** Dec 27, 2019
+* **Last change to this document:** Aug 23, 2020
 
 ## Highlights[](#highlights)
 

--- a/2.6.md
+++ b/2.6.md
@@ -7,9 +7,9 @@ next: 2.5
 # Ruby 2.6
 
 * **Released at:** Dec 25, 2018 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_6/NEWS) file)
-* **Status (as of Dec 27, 2019):** 2.6.5 is current _stable_
+* **Status (as of Aug 23, 2020):** 2.6.6 is current _stable_
 * **This document first published:** Dec 29, 2018
-* **Last change to this document:** Dec 27, 2019
+* **Last change to this document:** Aug 23, 2020
 
 > **Note:** As already explained in [Introduction](README.md), this site is dedicated to changes in the **language**, not the **implementation**, therefore the list below lacks mentions of lots of important optimization introduced in 2.6, including the whole JIT big thing. That's not because they are not important, just because this site's goals are different.
 

--- a/2.7.md
+++ b/2.7.md
@@ -7,9 +7,9 @@ next: 2.6
 # Ruby 2.7
 
 * **Released at:** Dec 25, 2019 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_7/NEWS) file)
-* **Status (as of Feb 28, 2020):** 2.7.0 is current _stable_
+* **Status (as of Aug 23, 2020):** 2.7.1 is current _stable_
 * **This document first published:** Dec 27, 2019
-* **Last change to this document:** Feb 28, 2020
+* **Last change to this document:** Aug 23, 2020
 
 <!-- TODO: all links to docs should be replaced with /2.7.0/ suffix instead of /master/ when 2.7.0 would be published -->
 
@@ -977,7 +977,7 @@ In 2.6, `resolve_feature_path` returned `false` instead of the path for already 
 
 Ruby 2.7 ships with an improved GC, which allows to manually defragment memory.
 
-* **Reason:** After some time of application running, creating objects and garbage collecting them, the memory becomes "defragmented": there are a large holes of unused memory between actual living objects. The new methods meant to be called between, say, spanning of the new processes/workers, potentially making current process using less memory.
+* **Reason:** After some time of application running, creating objects and garbage collecting them, the memory becomes "fragmented": there are a large holes of unused memory between actual living objects. The new methods meant to be called between, say, spanning of the new processes/workers, potentially making current process using less memory.
 * **Discussion:** <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/15626">Feature #15626</a>
 * **Documentation:** <a class="ruby-doc" href="https://ruby-doc.org/core-2.7.0/GC.html#method-c-compact"><code>GC.compact</code></a>
 * **Note:** This changelog author's understanding of GC and compacting is far from perfect, so the explanations are sparse. Unfortunately, the new feature is not thoroughly documented yet, so the best guess for understanding the change is reading "discussion" link above. The PRs (to the changelog and/or to the Ruby's main documentation) are welcome.
@@ -1048,14 +1048,14 @@ Allows to emit/suppress separate categories of warnings.
 
 ### Large IRB update[](#large-irb-update)
 
-IRB, Ruby's default console, received the hugest update in years. Now it supports multiline editing, syntax highlighting of input and (some of) output, auto-indentation and other modern console behavior. Small demonstration screenshot:
+IRB, Ruby's default console, received its biggest update in years. Now it supports multiline editing, syntax highlighting of input and (some) output, auto-indentation and other modern console behavior. Small demonstration screenshot:
 
 ![](images/irb_2.7.png)
 
 ### Network and web[](#network-and-web)
 
 * <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start"><code>Net::HTTP#start</code></a>: new optional keyword parameter `ipaddr:`, and <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html#method-i-ipaddr"><code>#ipaddr=</code></a> setter allows to set the address for the connection manually. Discussion: <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/5180">Feature #5180</a>.
-* `open-uri` library: 2 versions after more safe alias [was added](2.5.html#network-and-web), using `Kernel#open` finally became deprecated, and <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.7.0/libdoc/open-uri/rdoc/URI.html#method-c-open"><code>URI.open</code></a> the main library's interface. Discussion: <a class="tracker misc" href="https://bugs.ruby-lang.org/issues/15893">Misc #15893</a>
+* `open-uri` library: 2 versions after the safer alias [was added](2.5.html#network-and-web), using `Kernel#open` finally became deprecated, and <a class="ruby-doc" href="https://ruby-doc.org/stdlib-2.7.0/libdoc/open-uri/rdoc/URI.html#method-c-open"><code>URI.open</code></a> became the main library's interface. Discussion: <a class="tracker misc" href="https://bugs.ruby-lang.org/issues/15893">Misc #15893</a>
   ```ruby
   require 'open-uri'
   open('https://ruby-lang.org')

--- a/Contributing.md
+++ b/Contributing.md
@@ -11,7 +11,7 @@ Things you need to know, as of now:
 * The source is in `_src/<version>.md`;
 * To "compile" the final Jekyll site, you need to run `rake` in the main folder, or separate tasks (visible with `rake -T`):
   * `rake toc` (create TOC in `_data/book.yml`)
-  * `rake render` (postprocesses `./_src/<version>.md`→`./<version>.md` adding some nicer formatting not available in pure Markdown);
+  * `rake contents` (postprocesses `./_src/<version>.md`→`./<version>.md` adding some nicer formatting not available in pure Markdown);
 * Now you can run `jekyll serve` to preview the site locally.
 
 The main things to do, currently:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Some things to know about the content:
 * **UPD 2019-10-14:** **[Ruby 2.4](2.4.html)** changelog added, and some other content changed. See [History](/History.html) for detail.
 * **UPD 2019-12-27:** Newly released **[Ruby 2.7](2.7.html)** changelog added.
 
-_The source of the site can be found at [GitHub](https://github.com/rubyreferences/rubychanges). See also [Contributing](/rubychanges/Contributing.html) section._
+_The source of the site can be found at [GitHub](https://github.com/rubyreferences/rubychanges). See also the [Contributing](/Contributing.md) section._
 
 ## Credits and licenses
 

--- a/_src/2.4.md
+++ b/_src/2.4.md
@@ -15,7 +15,7 @@ prev: 2.5
  -->
 
 * **Released at:** Dec 25, 2016 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.4.0) file)
-* **Status (as of <<date>>):** EOL soon, latest is 2.4.9
+* **Status (as of <<date>>):** EOL, latest is 2.4.10
 * **This document first published:** Oct 14, 2019
 * **Last change to this document:** <<date>>
 
@@ -155,7 +155,7 @@ Returns an array of all modules used in the current scope.
 
 ### `Warning` module
 
-New single-method module was introduced, meant to be overriden in order to control warnings issued by Ruby.
+New single-method module was introduced, meant to be overridden in order to control warnings issued by Ruby.
 
 * **Reason:**
 * **Discussion:** [Feature #12299](https://bugs.ruby-lang.org/issues/12299)

--- a/_src/2.5.md
+++ b/_src/2.5.md
@@ -15,7 +15,7 @@ prev: 2.6
  -->
 
 * **Released at:** Dec 25, 2017 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.5.0) file)
-* **Status (as of <<date>>):** active, latest is 2.5.7
+* **Status (as of <<date>>):** Security maintenance, latest is 2.5.8
 * **This document first published:** Jun 6, 2019
 * **Last change to this document:** <<date>>
 

--- a/_src/2.6.md
+++ b/_src/2.6.md
@@ -7,7 +7,7 @@ next: 2.5
 # Ruby 2.6
 
 * **Released at:** Dec 25, 2018 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_6/NEWS) file)
-* **Status (as of <<date>>):** 2.6.5 is current _stable_
+* **Status (as of <<date>>):** 2.6.6 is current _stable_
 * **This document first published:** Dec 29, 2018
 * **Last change to this document:** <<date>>
 

--- a/_src/2.7.md
+++ b/_src/2.7.md
@@ -7,7 +7,7 @@ next: 2.6
 # Ruby 2.7
 
 * **Released at:** Dec 25, 2019 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_7/NEWS) file)
-* **Status (as of <<date>>):** 2.7.0 is current _stable_
+* **Status (as of <<date>>):** 2.7.1 is current _stable_
 * **This document first published:** Dec 27, 2019
 * **Last change to this document:** <<date>>
 
@@ -977,7 +977,7 @@ In 2.6, `resolve_feature_path` returned `false` instead of the path for already 
 
 Ruby 2.7 ships with an improved GC, which allows to manually defragment memory.
 
-* **Reason:** After some time of application running, creating objects and garbage collecting them, the memory becomes "defragmented": there are a large holes of unused memory between actual living objects. The new methods meant to be called between, say, spanning of the new processes/workers, potentially making current process using less memory.
+* **Reason:** After some time of application running, creating objects and garbage collecting them, the memory becomes "fragmented": there are a large holes of unused memory between actual living objects. The new methods meant to be called between, say, spanning of the new processes/workers, potentially making current process using less memory.
 * **Discussion:** [Feature #15626](https://bugs.ruby-lang.org/issues/15626)
 * **Documentation:** [GC.compact](https://ruby-doc.org/core-2.7.0/GC.html#method-c-compact)
 * **Note:** This changelog author's understanding of GC and compacting is far from perfect, so the explanations are sparse. Unfortunately, the new feature is not thoroughly documented yet, so the best guess for understanding the change is reading "discussion" link above. The PRs (to the changelog and/or to the Ruby's main documentation) are welcome.
@@ -1048,14 +1048,14 @@ Allows to emit/suppress separate categories of warnings.
 
 ### Large IRB update
 
-IRB, Ruby's default console, received the hugest update in years. Now it supports multiline editing, syntax highlighting of input and (some of) output, auto-indentation and other modern console behavior. Small demonstration screenshot:
+IRB, Ruby's default console, received its biggest update in years. Now it supports multiline editing, syntax highlighting of input and (some) output, auto-indentation and other modern console behavior. Small demonstration screenshot:
 
 ![](images/irb_2.7.png)
 
 ### Network and web
 
 * [Net::HTTP#start](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start): new optional keyword parameter `ipaddr:`, and [#ipaddr=](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html#method-i-ipaddr) setter allows to set the address for the connection manually. Discussion: [Feature #5180](https://bugs.ruby-lang.org/issues/5180).
-* `open-uri` library: 2 versions after more safe alias [was added](2.5.html#network-and-web), using `Kernel#open` finally became deprecated, and [URI.open](https://ruby-doc.org/stdlib-2.7.0/libdoc/open-uri/rdoc/URI.html#method-c-open) the main library's interface. Discussion: [Misc #15893](https://bugs.ruby-lang.org/issues/15893)
+* `open-uri` library: 2 versions after the safer alias [was added](2.5.html#network-and-web), using `Kernel#open` finally became deprecated, and [URI.open](https://ruby-doc.org/stdlib-2.7.0/libdoc/open-uri/rdoc/URI.html#method-c-open) became the main library's interface. Discussion: [Misc #15893](https://bugs.ruby-lang.org/issues/15893)
   ```ruby
   require 'open-uri'
   open('https://ruby-lang.org')


### PR DESCRIPTION
Thanks for a really cool project! It's always been kind of a headache to look this up. I noticed a few things when I was reading through various changes this morning and thought I would try to fix them up.

Summary of changes:
- Fixes typo of "overriden" -> "overridden".
- Corrects "defragmented" to "fragmented" since the feature of GC.compact is to defragment once something has _become_ fragmented.
- Changes "hugest" to "biggest".
- Changes "more safe" to "safer" and adjusts some surrounding grammar.
- Corrects rake command name of `render` -> `content` in Contributing.md
- Fixes broken Contributing link.
- Updates the current ruby versions and maintenance status for 2.4

LMK if you have any feedback or would like something removed/changed.

Thanks!