### PR TITLE
fix pattern matching example

### DIFF
--- a/3.0.md
+++ b/3.0.md
@@ -269,7 +269,7 @@ After the change described above, `in` was reintroduced to return `true`/`false`
 * **Code:**
   ```ruby
   user = {role: 'admin', login: 'matz'}
-  if user in {role: 'admin', name:}
+  if user in {role: 'admin', login: name}
     puts "Granting admin scope: #{name}"
   end
   # otherwise just proceed with regular scope, no need to raise


### PR DESCRIPTION
```
irb(main):007:0> user = {role: 'admin', login: 'matz'}
# before
=> {:role=>"admin", :login=>"matz"}
irb(main):008:1* if user in {role: 'admin', name:}
irb(main):009:1*   puts "Granting admin scope: #{name}"
irb(main):010:0> end
(irb):8: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
=> nil
# after
irb(main):014:1* if user in {role: 'admin', login: name}
irb(main):015:1*   puts "Granting admin scope: #{name}"
irb(main):016:0> end
(irb):14: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
Granting admin scope: matz
=> nil
```