### PR TITLE
Small copy changes to Ruby 3.0 page

### DIFF
--- a/_src/3.0.md
+++ b/_src/3.0.md
@@ -67,7 +67,7 @@ Just a leftover from the separation of keyword arguments.
   block = proc { |*args, **kwargs| puts "args=#{args}, kwargs=#{kwargs}"}
   block.call(1, 2, a: true)
   # Ruby 2.7: args=[1, 2], kwargs={:a=>true} -- as expected
-  # Ruby 2.7: args=[1, 2], kwargs={:a=>true} -- same
+  # Ruby 3.0: args=[1, 2], kwargs={:a=>true} -- same
   block.call(1, 2, {a: true})
   # Ruby 2.7:
   #  warning: Using the last argument as keyword parameters is deprecated
@@ -573,7 +573,7 @@ Now, when the second argument (`binding`) is passed to `eval`, `__FILE__` in eva
 
 #### `#include` and `#prepend` now affects modules including the receiver
 
-If class `C` includes module `M`, and after that we did `M.include M1`, before Ruby 3.0, `M1` have not included into `C`; and now it is.
+If class `C` includes module `M`, and after that we did `M.include M1`, before Ruby 3.0, `M1` would not have been included into `C`; and now it is.
 
 * **Reason:** The behavior was long-standing and led to a lot of confusion (especially considering that including something in the class _did_ affected its descendants).
 * **Discussion:** [Feature #9573](https://bugs.ruby-lang.org/issues/9573)


### PR DESCRIPTION
One fix to a copy/paste error in a code example.
Another adjusting the phrasing on a paragraph.