### PR TITLE
Ruby 3.0.1, 2.7.3, 2.6.7 and 2.5.8

### DIFF
--- a/2.5.md
+++ b/2.5.md
@@ -15,9 +15,9 @@ prev: 2.6
  -->
 
 * **Released at:** Dec 25, 2017 (<a class="github" href="https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.5.0">NEWS</a> file)
-* **Status (as of Dec 30, 2020):** Security maintenance, latest is 2.5.8
+* **Status (as of May 18, 2021):** EOL, latest is 2.5.9
 * **This document first published:** Jun 6, 2019
-* **Last change to this document:** Dec 30, 2020
+* **Last change to this document:** May 18, 2021
 
 ## Highlights[](#highlights)
 

--- a/2.6.md
+++ b/2.6.md
@@ -7,9 +7,9 @@ next: 2.5
 # Ruby 2.6
 
 * **Released at:** Dec 25, 2018 (<a class="github" href="https://github.com/ruby/ruby/blob/ruby_2_6/NEWS">NEWS</a> file)
-* **Status (as of Dec 30, 2020):** 2.6.6 is current _stable_
+* **Status (as of May 18, 2021):** Security maintenance, latest is 2.6.7
 * **This document first published:** Dec 29, 2018
-* **Last change to this document:** Dec 30, 2020
+* **Last change to this document:** May 18, 2021
 
 > **Note:** As already explained in [Introduction](README.md), this site is dedicated to changes in the **language**, not the **implementation**, therefore the list below lacks mentions of lots of important optimization introduced in 2.6, including the whole JIT big thing. That's not because they are not important, just because this site's goals are different.
 

--- a/2.7.md
+++ b/2.7.md
@@ -7,9 +7,9 @@ next: 2.6
 # Ruby 2.7
 
 * **Released at:** Dec 25, 2019 (<a class="github" href="https://github.com/ruby/ruby/blob/ruby_2_7/NEWS">NEWS</a> file)
-* **Status (as of Dec 30, 2020):** 2.7.2 is current _stable_
+* **Status (as of May 18, 2021):** 2.7.3 is current _stable_
 * **This document first published:** Dec 27, 2019
-* **Last change to this document:** Dec 30, 2020
+* **Last change to this document:** May 18, 2021
 
 <!-- TODO: all links to docs should be replaced with /2.7.0/ suffix instead of /master/ when 2.7.0 would be published -->
 

--- a/3.0.md
+++ b/3.0.md
@@ -7,9 +7,9 @@ next: 2.7
 # Ruby 3.0
 
 * **Released at:** Dec 25, 2020 (<a class="github" href="https://github.com/ruby/ruby/blob/ruby_3_0/NEWS.md">NEWS.md</a> file)
-* **Status (as of Jan 09, 2021):** Stable, just released
+* **Status (as of May 18, 2021):** 3.0.1 is current _stable_
 * **This document first published:** Dec 25, 2020
-* **Last change to this document:** Jan 09, 2021
+* **Last change to this document:** May 18, 2021
 
 ## Highlights[](#highlights)
 

--- a/_src/2.5.md
+++ b/_src/2.5.md
@@ -15,7 +15,7 @@ prev: 2.6
  -->
 
 * **Released at:** Dec 25, 2017 ([NEWS](https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.5.0) file)
-* **Status (as of <<date>>):** Security maintenance, latest is 2.5.8
+* **Status (as of <<date>>):** EOL, latest is 2.5.9
 * **This document first published:** Jun 6, 2019
 * **Last change to this document:** <<date>>
 

--- a/_src/2.6.md
+++ b/_src/2.6.md
@@ -7,7 +7,7 @@ next: 2.5
 # Ruby 2.6
 
 * **Released at:** Dec 25, 2018 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_6/NEWS) file)
-* **Status (as of <<date>>):** 2.6.6 is current _stable_
+* **Status (as of <<date>>):** Security maintenance, latest is 2.6.7
 * **This document first published:** Dec 29, 2018
 * **Last change to this document:** <<date>>
 

--- a/_src/2.7.md
+++ b/_src/2.7.md
@@ -7,7 +7,7 @@ next: 2.6
 # Ruby 2.7
 
 * **Released at:** Dec 25, 2019 ([NEWS](https://github.com/ruby/ruby/blob/ruby_2_7/NEWS) file)
-* **Status (as of <<date>>):** 2.7.2 is current _stable_
+* **Status (as of <<date>>):** 2.7.3 is current _stable_
 * **This document first published:** Dec 27, 2019
 * **Last change to this document:** <<date>>
 

--- a/_src/3.0.md
+++ b/_src/3.0.md
@@ -7,7 +7,7 @@ next: 2.7
 # Ruby 3.0
 
 * **Released at:** Dec 25, 2020 ([NEWS.md](https://github.com/ruby/ruby/blob/ruby_3_0/NEWS.md) file)
-* **Status (as of <<date>>):** Stable, just released
+* **Status (as of <<date>>):** 3.0.1 is current _stable_
 * **This document first published:** Dec 25, 2020
 * **Last change to this document:** <<date>>
 


### PR DESCRIPTION
were released on 5 April 2021:

Ruby 3.0.1 released
https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/

Ruby 2.7.3 released
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/

Ruby 2.6.7 released and entered security maintenance phase
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/

Ruby 2.5.9 released and reached EOL
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/