### PR TITLE
Remove trailing incomplete sentence

### DIFF
--- a/3.1.md
+++ b/3.1.md
@@ -984,7 +984,7 @@ Returns OS-specific thread ID.
 
 The new method is the process forking implementation which is guaranteed to be used by both `Process.fork`, `Kernel#fork`, and `IO.popen`.
 
-* **Reason:** The method is meant to be overridable by libraries that need to add some hook/additional processing (like freeing DB connections) on forking. Previously, this was inconvenient due to the fact that `Process.fork` and `Kernel#fork` were different methods, not relying on each other. Providing
+* **Reason:** The method is meant to be overridable by libraries that need to add some hook/additional processing (like freeing DB connections) on forking. Previously, this was inconvenient due to the fact that `Process.fork` and `Kernel#fork` were different methods, not relying on each other.
 * **Discussion:** <a class="tracker feature" href="https://bugs.ruby-lang.org/issues/17795">Feature #17795</a>
 * **Documentation:** <a class="ruby-doc" href="https://docs.ruby-lang.org/en/3.1/Process.html#method-c-_fork"><code>Process.\_fork</code></a>
 * **Code:**

--- a/_src/3.1.md
+++ b/_src/3.1.md
@@ -984,7 +984,7 @@ Returns OS-specific thread ID.
 
 The new method is the process forking implementation which is guaranteed to be used by both `Process.fork`, `Kernel#fork`, and `IO.popen`.
 
-* **Reason:** The method is meant to be overridable by libraries that need to add some hook/additional processing (like freeing DB connections) on forking. Previously, this was inconvenient due to the fact that `Process.fork` and `Kernel#fork` were different methods, not relying on each other. Providing
+* **Reason:** The method is meant to be overridable by libraries that need to add some hook/additional processing (like freeing DB connections) on forking. Previously, this was inconvenient due to the fact that `Process.fork` and `Kernel#fork` were different methods, not relying on each other.
 * **Discussion:** [Feature #17795](https://bugs.ruby-lang.org/issues/17795)
 * **Documentation:** [Process.\_fork](https://docs.ruby-lang.org/en/3.1/Process.html#method-c-_fork)
 * **Code:**


### PR DESCRIPTION
This is manually edited so you might want to check that it renders properly. I couldn't bundle install because it looks like a dependency is yanked:


> Your bundle is locked to dnsruby (1.61.8), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of dnsruby (1.61.8) has
removed it. You'll need to update your bundle to a version other than dnsruby (1.61.8) that hasn't been removed in order to install.

Also, while I have your attention, it looks like the "Pattern-matching: pinning of expressions" link in the highlight section is broken on the site. https://rubyreferences.github.io/rubychanges/3.1.html
Looks like the generated anchor has an unexpected extra dash at the end:

https://github.com/XrXr/rubychanges/blob/c3180f9b2c822febc3828f5900754a19559d8493/3.1.md?plain=1#L149