### PR TITLE
Fix WeakKeyMap code example

### DIFF
--- a/_src/3.3.md
+++ b/_src/3.3.md
@@ -421,7 +421,7 @@ A new "weak map" concept implementation. Unlike `ObjectSpace::WeakMap`, it compa
 * **Documentation:** [ObjectSpace::WeakKeyMap](https://docs.ruby-lang.org/en/master/ObjectSpace/WeakKeyMap.html)
 * **Code:**
   ```ruby
-  map = ObjectSpace::WeekMap.new
+  map = ObjectSpace::WeakKeyMap.new
 
   key = "foo"
   map[key] = true


### PR DESCRIPTION
The code block used `ObjectSpace::WeekMap` rather than the intended `ObjectSpace::WeakKeyMap`.