### PR TITLE
Fix Fiber#kill rendering

### DIFF
--- a/_src/3.3.md
+++ b/_src/3.3.md
@@ -730,6 +730,7 @@ Terminates the Fiber by sending an exception inside it.
 * **Notes:**
   * The exception sent to Fiber is _uncatchable_ (so no `rescue Exception` will notice it), so it can't be said that it has some _class_; the only usage of the fact that it is raised through exception mechanism is invoking `ensure` block;
   * The fibers that was invoking the killed one with `resume` or `transfer`, receives `nil` from that call;
+
   ```ruby
   f1 = Fiber.new {
     # Instead of yielding something back, the fiber kills itself
@@ -744,6 +745,7 @@ Terminates the Fiber by sending an exception inside it.
   f2.resume
   # prints: {:result => nil}
   ```
+
   * Only fibers belonging to the same thread can be killed.
 
 ### Internals


### PR DESCRIPTION
Without the newlines, GH Pages was rendering this code block as plain text, not a Ruby code block as intended.

Before:
![Screenshot 2023-12-28 at 17-07-41 Ruby 3 3 changes](https://github.com/rubyreferences/rubychanges/assets/5786847/6788f7b7-dd7b-4755-a63d-78daf244c611)
After:
![Screenshot 2023-12-28 at 17-07-55 Ruby 3 3 changes](https://github.com/rubyreferences/rubychanges/assets/5786847/2dc454ee-6f55-45fa-a353-f128aed15de6)
