### PR TITLE
Add missing minus sign for Range#overlap? section

### DIFF
--- a/3.3.md
+++ b/3.3.md
@@ -566,7 +566,7 @@ Checks for overlapping of two ranges.
   (1..3).overlap?(1)
   # `overlap?': wrong argument type Integer (expected Range) (TypeError)
   ```
-* **Notes:** As documentation points out, the _technically empty_ `(...-Float::INFINITY)` range (nothing can be lower than `Float::INFINITY`, and it is not included) still considered overlapping with itself by this method:
+* **Notes:** As documentation points out, the _technically empty_ `(...-Float::INFINITY)` range (nothing can be lower than `-Float::INFINITY`, and it is not included) still considered overlapping with itself by this method:
   ```ruby
   (...-Float::INFINITY).overlap?(...-Float::INFINITY) #=> true
   # Same with other "nothing could be smaller" ranges:


### PR DESCRIPTION
There is a minus sign missing in the explanation for the `Range#overlap?` section.

Thank you for this great summary of Ruby changes, I enjoy it every time! 👏 