### PR TITLE
Fix Set examples for 4.0

### DIFF
--- a/4.0.md
+++ b/4.0.md
@@ -8,9 +8,9 @@ description: Ruby 4.0 full and annotated changelog
 # Ruby 4.0
 
 * **Released at:** Dec 25, 2025 (<a class="github" href="https://github.com/ruby/ruby/blob/v4.0.0/NEWS.md">NEWS.md</a> file)
-* **Status (as of Dec 26, 2025):** 4.0 is just released
+* **Status (as of Jan 09, 2026):** 4.0 is just released
 * **This document first published:** Dec 26, 2025
-* **Last change to this document:** Dec 26, 2025
+* **Last change to this document:** Jan 09, 2026
 
 <!--
 * **Reason:**
@@ -352,7 +352,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
   # Note that if your code relied on `@hash` instance variable directly
   # (which it shouldn't have), it will be broken despite the compatibility
   # layer:
-  class SmallStringsSet
+  class SmallStringSet
     # Somebody decided using internal variable would be more efficient
     def numeric? = @hash.keys.all?(Numeric)
   end

--- a/4.0.md
+++ b/4.0.md
@@ -339,7 +339,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
 
   # Now, as methods of SubclassCompatible are implemented mostly as they were before,
   # old assumptions work:
-  class SmallStringSet
+  class SmallStringSet < Set
     def initialize(items) = super(items.to_a[...5])
     def add(item) = super(item.to_s)
   end
@@ -352,7 +352,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
   # Note that if your code relied on `@hash` instance variable directly
   # (which it shouldn't have), it will be broken despite the compatibility
   # layer:
-  class SmallStringSet
+  class SmallStringSet < Set
     # Somebody decided using internal variable would be more efficient
     def numeric? = @hash.keys.all?(Numeric)
   end
@@ -371,7 +371,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
 
   # It would be faster, but the assumptions which methods calls which
   # internally aren't necessary correct anymore
-  class SmallStringSet2
+  class SmallStringSet2 < Set::CoreSet
     def initialize(items) = super(items.to_a[...5])
     def add(item) = super(item.to_s)
   end

--- a/_src/4.0.md
+++ b/_src/4.0.md
@@ -352,7 +352,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
   # Note that if your code relied on `@hash` instance variable directly
   # (which it shouldn't have), it will be broken despite the compatibility
   # layer:
-  class SmallStringsSet
+  class SmallStringSet
     # Somebody decided using internal variable would be more efficient
     def numeric? = @hash.keys.all?(Numeric)
   end

--- a/_src/4.0.md
+++ b/_src/4.0.md
@@ -339,7 +339,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
 
   # Now, as methods of SubclassCompatible are implemented mostly as they were before,
   # old assumptions work:
-  class SmallStringSet
+  class SmallStringSet < Set
     def initialize(items) = super(items.to_a[...5])
     def add(item) = super(item.to_s)
   end
@@ -352,7 +352,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
   # Note that if your code relied on `@hash` instance variable directly
   # (which it shouldn't have), it will be broken despite the compatibility
   # layer:
-  class SmallStringSet
+  class SmallStringSet < Set
     # Somebody decided using internal variable would be more efficient
     def numeric? = @hash.keys.all?(Numeric)
   end
@@ -371,7 +371,7 @@ By redefinining `#instance_variables_to_inspect`, the default output of `#inspec
 
   # It would be faster, but the assumptions which methods calls which
   # internally aren't necessary correct anymore
-  class SmallStringSet2
+  class SmallStringSet2 < Set::CoreSet
     def initialize(items) = super(items.to_a[...5])
     def add(item) = super(item.to_s)
   end


### PR DESCRIPTION
The classes were named inconsistently so that the examples would not work at all.

In the second commit, I also added the parent class to all class definitions to make it clearer what the parents are, even though this is not strictly necessary for any of the re-opened classes.